### PR TITLE
12/22 make Makefile and prepare.sh for test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SLDS = base candy charhan charhan2 contest contest2 ct eye hoe hoehoe lattice \
+lattice2 noe piero1 pika rot shuttle ss20 tron
+
+default: test
+
+clean:
+	rm -f unicaml suiteki sim lib min-rt.unicaml min-rt.s sld/*.ppm sld/*.ppm.tmp sld/*.png *~
+
+test: $(SLDS:%=sld/%.unicaml.ppm)
+
+prepare:
+	./prepare.sh
+
+sld/%.unicaml.ppm: sld/%.sld min-rt.unicaml prepare
+	./sim -i $< -o $@.tmp min-rt.unicaml
+	mv $@.tmp $@
+
+min-rt.unicaml: min-rt.s
+	./suiteki $< -o $@ -l lib/libmincaml.S
+
+min-rt.s: min-rt.ml
+	./unicaml min-rt

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+COM=../unicaml # the root dir of the compiler
+ASM=../suiteki # the root dir of the assembler
+SIM=../../simulator # the root dir of the simulator
+
+echo 'Building compiler...'
+cd $COM
+make byte-code
+cd -> /dev/null
+
+echo 'Building assembla...'
+cd $ASM
+cabal build
+cd - > /dev/null
+
+echo 'Building simulator...'
+cd $SIM
+make
+cd -> /dev/null
+
+echo 'Creating symbolic links for make...'
+ln -sf $COM/unicaml ./unicaml
+ln -sf $ASM/dist/build/suiteki/suiteki ./suiteki
+ln -sf $ASM/lib ./lib
+ln -sf $SIM/sim ./sim


### PR DESCRIPTION
raytracerのテストの自動化のためにMakefileとprepare.sh書きました。
今のところ、makeで全部のsldファイルをテストするように書いています。
prepare.shのソースの位置は、1stでは各自書き換える方針で。